### PR TITLE
feat: speed up random data and improve randomness distribution

### DIFF
--- a/src/ulid_transform/ulid_struct.hh
+++ b/src/ulid_transform/ulid_struct.hh
@@ -341,11 +341,10 @@ inline void EncodeEntropyRand(ULID& ulid)
  * */
 inline void EncodeEntropyMt19937Fast(ULID& ulid)
 {
-    thread_local std::mt19937 gen([]() {
-        // Use multiple entropy sources for seeding
+    static std::mt19937 gen([]() {
         std::array<uint32_t, 3> seed_data = {
             static_cast<uint32_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count()),
-            static_cast<uint32_t>(std::random_device {}()),
+            std::random_device {}(),
             static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&gen) & 0xFFFFFFFF)
         };
         std::seed_seq seed_seq(seed_data.begin(), seed_data.end());

--- a/src/ulid_transform/ulid_struct.hh
+++ b/src/ulid_transform/ulid_struct.hh
@@ -341,8 +341,16 @@ inline void EncodeEntropyRand(ULID& ulid)
  * */
 inline void EncodeEntropyMt19937Fast(ULID& ulid)
 {
-    static std::random_device rd;
-    static std::mt19937 gen(rd());
+    thread_local std::mt19937 gen([]() {
+        // Use multiple entropy sources for seeding
+        std::array<uint32_t, 3> seed_data = {
+            static_cast<uint32_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count()),
+            static_cast<uint32_t>(std::random_device {}()),
+            static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&gen) & 0xFFFFFFFF)
+        };
+        std::seed_seq seed_seq(seed_data.begin(), seed_data.end());
+        return std::mt19937(seed_seq);
+    }());
     uint64_t high = (static_cast<uint64_t>(gen()) << 32) | gen();
     uint32_t low = gen();
     ulid.data[6] = (high >> 40) & 0xFF;

--- a/src/ulid_transform/ulid_struct.hh
+++ b/src/ulid_transform/ulid_struct.hh
@@ -323,16 +323,18 @@ inline void EncodeEntropy(const std::function<uint8_t()>& rng, ULID& ulid)
  * */
 inline void EncodeEntropyRand(ULID& ulid)
 {
-    ulid.data[6] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
-    ulid.data[7] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
-    ulid.data[8] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
-    ulid.data[9] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
-    ulid.data[10] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
-    ulid.data[11] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
-    ulid.data[12] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
-    ulid.data[13] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
-    ulid.data[14] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
-    ulid.data[15] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
+    uint64_t high = (static_cast<uint64_t>(std::rand()) << 32) | std::rand();
+    uint32_t low = std::rand();
+    ulid.data[6] = static_cast<uint8_t>(high >> 56);
+    ulid.data[7] = static_cast<uint8_t>(high >> 48);
+    ulid.data[8] = static_cast<uint8_t>(high >> 40);
+    ulid.data[9] = static_cast<uint8_t>(high >> 32);
+    ulid.data[10] = static_cast<uint8_t>(high >> 24);
+    ulid.data[11] = static_cast<uint8_t>(high >> 16);
+    ulid.data[12] = static_cast<uint8_t>(high >> 8);
+    ulid.data[13] = static_cast<uint8_t>(high);
+    ulid.data[14] = static_cast<uint8_t>(low >> 24);
+    ulid.data[15] = static_cast<uint8_t>(low >> 16);
 }
 
 static std::uniform_int_distribution<rand_t> Distribution_0_255(0, 255);

--- a/src/ulid_transform/ulid_struct.hh
+++ b/src/ulid_transform/ulid_struct.hh
@@ -342,7 +342,7 @@ inline void EncodeEntropyRand(ULID& ulid)
  * */
 inline void EncodeEntropyMt19937Fast(ULID& ulid)
 {
-    thread_local std::mt19937 gen([]() {
+    static thread_local std::mt19937 gen([]() {
         // Use multiple entropy sources for seeding
         std::array<uint32_t, 3> seed_data = {
             static_cast<uint32_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count()),

--- a/src/ulid_transform/ulid_struct.hh
+++ b/src/ulid_transform/ulid_struct.hh
@@ -335,6 +335,28 @@ inline void EncodeEntropyRand(ULID& ulid)
     ulid.data[15] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
 }
 
+/**
+ * EncodeEntropyMt19937Fast will encode using std::mt19937
+ * with only 3 generated values.
+ * */
+inline void EncodeEntropyMt19937Fast(ULID& ulid)
+{
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    uint64_t high = (static_cast<uint64_t>(gen()) << 32) | gen();
+    uint32_t low = gen();
+    ulid.data[6] = (high >> 40) & 0xFF;
+    ulid.data[7] = (high >> 32) & 0xFF;
+    ulid.data[8] = (high >> 24) & 0xFF;
+    ulid.data[9] = (high >> 16) & 0xFF;
+    ulid.data[10] = (high >> 8) & 0xFF;
+    ulid.data[11] = high & 0xFF;
+    ulid.data[12] = (low >> 24) & 0xFF;
+    ulid.data[13] = (low >> 16) & 0xFF;
+    ulid.data[14] = (low >> 8) & 0xFF;
+    ulid.data[15] = low & 0xFF;
+}
+
 static std::uniform_int_distribution<rand_t> Distribution_0_255(0, 255);
 
 /**

--- a/src/ulid_transform/ulid_struct.hh
+++ b/src/ulid_transform/ulid_struct.hh
@@ -323,18 +323,16 @@ inline void EncodeEntropy(const std::function<uint8_t()>& rng, ULID& ulid)
  * */
 inline void EncodeEntropyRand(ULID& ulid)
 {
-    uint64_t high = (static_cast<uint64_t>(std::rand()) << 32) | std::rand();
-    uint32_t low = std::rand();
-    ulid.data[6] = static_cast<uint8_t>(high >> 56);
-    ulid.data[7] = static_cast<uint8_t>(high >> 48);
-    ulid.data[8] = static_cast<uint8_t>(high >> 40);
-    ulid.data[9] = static_cast<uint8_t>(high >> 32);
-    ulid.data[10] = static_cast<uint8_t>(high >> 24);
-    ulid.data[11] = static_cast<uint8_t>(high >> 16);
-    ulid.data[12] = static_cast<uint8_t>(high >> 8);
-    ulid.data[13] = static_cast<uint8_t>(high);
-    ulid.data[14] = static_cast<uint8_t>(low >> 24);
-    ulid.data[15] = static_cast<uint8_t>(low >> 16);
+    ulid.data[6] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
+    ulid.data[7] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
+    ulid.data[8] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
+    ulid.data[9] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
+    ulid.data[10] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
+    ulid.data[11] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
+    ulid.data[12] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
+    ulid.data[13] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
+    ulid.data[14] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
+    ulid.data[15] = static_cast<uint8_t>((std::rand() * 255ull) / RAND_MAX);
 }
 
 static std::uniform_int_distribution<rand_t> Distribution_0_255(0, 255);

--- a/src/ulid_transform/ulid_struct.hh
+++ b/src/ulid_transform/ulid_struct.hh
@@ -1,6 +1,7 @@
 #ifndef ULID_STRUCT_HH
 #define ULID_STRUCT_HH
 
+#include <array>
 #include <chrono>
 #include <cstdlib>
 #include <ctime>

--- a/src/ulid_transform/ulid_struct.hh
+++ b/src/ulid_transform/ulid_struct.hh
@@ -341,10 +341,11 @@ inline void EncodeEntropyRand(ULID& ulid)
  * */
 inline void EncodeEntropyMt19937Fast(ULID& ulid)
 {
-    static std::mt19937 gen([]() {
+    thread_local std::mt19937 gen([]() {
+        // Use multiple entropy sources for seeding
         std::array<uint32_t, 3> seed_data = {
             static_cast<uint32_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count()),
-            std::random_device {}(),
+            static_cast<uint32_t>(std::random_device {}()),
             static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&gen) & 0xFFFFFFFF)
         };
         std::seed_seq seed_seq(seed_data.begin(), seed_data.end());

--- a/src/ulid_transform/ulid_uint128.hh
+++ b/src/ulid_transform/ulid_uint128.hh
@@ -179,9 +179,7 @@ inline void EncodeEntropyMt19937Fast(ULID& ulid)
         return std::mt19937(seed_seq);
     }());
     ulid = (ulid >> 80) << 80; // Clear lower 80 bits
-    uint64_t high = static_cast<uint64_t>(gen()) << 32 | gen();
-    uint32_t low = gen();
-    ulid |= (high << 16) | (low >> 16);
+    ulid |= (static_cast<uint64_t>(gen()) << 48) | (static_cast<uint64_t>(gen()) << 16) | (gen() >> 16);
 }
 
 static std::uniform_int_distribution<rand_t> Distribution_0_255(0, 255);

--- a/src/ulid_transform/ulid_uint128.hh
+++ b/src/ulid_transform/ulid_uint128.hh
@@ -128,10 +128,8 @@ inline void EncodeEntropy(const std::function<uint8_t()>& rng, ULID& ulid)
 inline void EncodeEntropyRand(ULID& ulid)
 {
     ulid = (ulid >> 80) << 80;
-    static std::random_device rd;
-    static std::mt19937 gen(rd());
-    uint64_t high = static_cast<uint64_t>(gen()) << 32 | gen();
-    uint32_t low = gen();
+    uint64_t high = (static_cast<uint64_t>(std::rand()) << 32) | std::rand();
+    uint32_t low = std::rand();
     ulid |= (high << 16) | (low >> 16);
 }
 

--- a/src/ulid_transform/ulid_uint128.hh
+++ b/src/ulid_transform/ulid_uint128.hh
@@ -124,13 +124,17 @@ inline void EncodeEntropy(const std::function<uint8_t()>& rng, ULID& ulid)
  * BitsPerRand will return the number of bits in the return value of std::rand
  *
  * */
-constexpr int BitsPerRand()
-{
-    int bits = 0;
-    for (int max = RAND_MAX; max > 0; max >>= 1) {
-        bits++;
+namespace {
+    int CalculateBitsPerRand()
+    {
+        int bits = 0;
+        for (int max = RAND_MAX; max > 0; max >>= 1) {
+            ++bits;
+        }
+        return bits;
     }
-    return bits;
+
+    const int bitsPerRand = CalculateBitsPerRand();
 }
 
 /**
@@ -144,7 +148,6 @@ inline void EncodeEntropyRand(ULID& ulid)
 
     ULID e = 0;
     int randBits = 0;
-    constexpr int bitsPerRand = BitsPerRand();
 
     while (randBits < 80) {
         e <<= bitsPerRand;

--- a/src/ulid_transform/ulid_uint128.hh
+++ b/src/ulid_transform/ulid_uint128.hh
@@ -179,7 +179,7 @@ inline void EncodeEntropyMt19937Fast(ULID& ulid)
         return std::mt19937(seed_seq);
     }());
     ulid = (ulid >> 80) << 80; // Clear lower 80 bits
-    ulid |= (static_cast<uint64_t>(gen()) << 48) | (static_cast<uint64_t>(gen()) << 16) | (gen() >> 16);
+    ulid |= (static_cast<ULID>((static_cast<uint64_t>(gen()) << 32) | gen()) << 16) | (gen() & 0xFFFF);
 }
 
 static std::uniform_int_distribution<rand_t> Distribution_0_255(0, 255);

--- a/src/ulid_transform/ulid_uint128.hh
+++ b/src/ulid_transform/ulid_uint128.hh
@@ -168,7 +168,7 @@ inline void EncodeEntropyRand(ULID& ulid)
  * */
 inline void EncodeEntropyMt19937Fast(ULID& ulid)
 {
-    thread_local std::mt19937 gen([]() {
+    static thread_local std::mt19937 gen([]() {
         // Use multiple entropy sources for seeding
         std::array<uint32_t, 3> seed_data = {
             static_cast<uint32_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count()),

--- a/src/ulid_transform/ulid_uint128.hh
+++ b/src/ulid_transform/ulid_uint128.hh
@@ -128,12 +128,36 @@ inline void EncodeEntropy(const std::function<uint8_t()>& rng, ULID& ulid)
 inline void EncodeEntropyRand(ULID& ulid)
 {
     ulid = (ulid >> 80) << 80;
-    ULID e = std::rand();
-    e <<= 31;
-    e |= std::rand();
-    e <<= 31;
-    e |= std::rand();
-    e <<= 18;
+
+    ULID e = (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
     ulid |= e;
 }
 

--- a/src/ulid_transform/ulid_uint128.hh
+++ b/src/ulid_transform/ulid_uint128.hh
@@ -128,36 +128,12 @@ inline void EncodeEntropy(const std::function<uint8_t()>& rng, ULID& ulid)
 inline void EncodeEntropyRand(ULID& ulid)
 {
     ulid = (ulid >> 80) << 80;
-
-    ULID e = (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
+    ULID e = std::rand();
+    e <<= 31;
+    e |= std::rand();
+    e <<= 31;
+    e |= std::rand();
+    e <<= 18;
     ulid |= e;
 }
 

--- a/src/ulid_transform/ulid_uint128.hh
+++ b/src/ulid_transform/ulid_uint128.hh
@@ -128,37 +128,11 @@ inline void EncodeEntropy(const std::function<uint8_t()>& rng, ULID& ulid)
 inline void EncodeEntropyRand(ULID& ulid)
 {
     ulid = (ulid >> 80) << 80;
-
-    ULID e = (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    e <<= 8;
-    e |= (std::rand() * 255ull) / RAND_MAX;
-
-    ulid |= e;
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    uint64_t high = static_cast<uint64_t>(gen()) << 32 | gen();
+    uint32_t low = gen();
+    ulid |= (high << 16) | (low >> 16);
 }
 
 static std::uniform_int_distribution<rand_t> Distribution_0_255(0, 255);

--- a/src/ulid_transform/ulid_uint128.hh
+++ b/src/ulid_transform/ulid_uint128.hh
@@ -167,17 +167,20 @@ inline void EncodeEntropyRand(ULID& ulid)
  * */
 inline void EncodeEntropyMt19937Fast(ULID& ulid)
 {
-    static std::mt19937 gen([]() {
+    thread_local std::mt19937 gen([]() {
+        // Use multiple entropy sources for seeding
         std::array<uint32_t, 3> seed_data = {
             static_cast<uint32_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count()),
-            std::random_device {}(),
+            static_cast<uint32_t>(std::random_device {}()),
             static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&gen) & 0xFFFFFFFF)
         };
         std::seed_seq seed_seq(seed_data.begin(), seed_data.end());
         return std::mt19937(seed_seq);
     }());
     ulid = (ulid >> 80) << 80; // Clear lower 80 bits
-    ulid |= (static_cast<uint64_t>(gen()) << 48) | (static_cast<uint64_t>(gen()) << 16) | (gen() >> 16);
+    uint64_t high = static_cast<uint64_t>(gen()) << 32 | gen();
+    uint32_t low = gen();
+    ulid |= (high << 16) | (low >> 16);
 }
 
 static std::uniform_int_distribution<rand_t> Distribution_0_255(0, 255);

--- a/src/ulid_transform/ulid_uint128.hh
+++ b/src/ulid_transform/ulid_uint128.hh
@@ -1,6 +1,7 @@
 #ifndef ULID_UINT128_HH
 #define ULID_UINT128_HH
 
+#include <array>
 #include <chrono>
 #include <cstdlib>
 #include <ctime>

--- a/src/ulid_transform/ulid_uint128.hh
+++ b/src/ulid_transform/ulid_uint128.hh
@@ -124,18 +124,16 @@ inline void EncodeEntropy(const std::function<uint8_t()>& rng, ULID& ulid)
  * BitsPerRand will return the number of bits in the return value of std::rand
  *
  * */
-namespace {
-    int CalculateBitsPerRand()
-    {
-        int bits = 0;
-        for (int max = RAND_MAX; max > 0; max >>= 1) {
-            ++bits;
-        }
-        return bits;
+int CalculateBitsPerRand()
+{
+    int bits = 0;
+    for (int max = RAND_MAX; max > 0; max >>= 1) {
+        ++bits;
     }
-
-    const int bitsPerRand = CalculateBitsPerRand();
+    return bits;
 }
+
+const int bitsPerRand = CalculateBitsPerRand();
 
 /**
  * EncodeEntropyRand will encode a ulid using std::rand

--- a/src/ulid_transform/ulid_uint128.hh
+++ b/src/ulid_transform/ulid_uint128.hh
@@ -121,43 +121,58 @@ inline void EncodeEntropy(const std::function<uint8_t()>& rng, ULID& ulid)
 }
 
 /**
- * BitsPerRand will return the number of bits in the return value of std::rand
- *
- * */
-int CalculateBitsPerRand()
-{
-    int bits = 0;
-    for (int max = RAND_MAX; max > 0; max >>= 1) {
-        ++bits;
-    }
-    return bits;
-}
-
-const int bitsPerRand = CalculateBitsPerRand();
-
-/**
  * EncodeEntropyRand will encode a ulid using std::rand
  *
  * std::rand returns values in [0, RAND_MAX]
  * */
 inline void EncodeEntropyRand(ULID& ulid)
 {
-    ulid = (ulid >> 80) << 80; // Clear lower 80 bits
+    ulid = (ulid >> 80) << 80;
 
-    ULID e = 0;
-    int randBits = 0;
+    ULID e = (std::rand() * 255ull) / RAND_MAX;
 
-    while (randBits < 80) {
-        e <<= bitsPerRand;
-        e |= static_cast<ULID>(std::rand());
-        randBits += bitsPerRand;
-    }
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
 
-    if (randBits > 80) {
-        e >>= (randBits - 80); // Trim excess bits
-    }
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
+
+    e <<= 8;
+    e |= (std::rand() * 255ull) / RAND_MAX;
 
     ulid |= e;
+}
+
+/**
+ * EncodeEntropyMt19937Fast will encode using std::mt19937
+ * with only 3 generated values.
+ * */
+inline void EncodeEntropyMt19937Fast(ULID& ulid)
+{
+    ulid = (ulid >> 80) << 80; // Clear lower 80 bits
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    uint64_t high = static_cast<uint64_t>(gen()) << 32 | gen();
+    uint32_t low = gen();
+    ulid |= (high << 16) | (low >> 16);
 }
 
 static std::uniform_int_distribution<rand_t> Distribution_0_255(0, 255);

--- a/src/ulid_transform/ulid_uint128.hh
+++ b/src/ulid_transform/ulid_uint128.hh
@@ -167,20 +167,17 @@ inline void EncodeEntropyRand(ULID& ulid)
  * */
 inline void EncodeEntropyMt19937Fast(ULID& ulid)
 {
-    thread_local std::mt19937 gen([]() {
-        // Use multiple entropy sources for seeding
+    static std::mt19937 gen([]() {
         std::array<uint32_t, 3> seed_data = {
             static_cast<uint32_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count()),
-            static_cast<uint32_t>(std::random_device {}()),
+            std::random_device {}(),
             static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&gen) & 0xFFFFFFFF)
         };
         std::seed_seq seed_seq(seed_data.begin(), seed_data.end());
         return std::mt19937(seed_seq);
     }());
     ulid = (ulid >> 80) << 80; // Clear lower 80 bits
-    uint64_t high = static_cast<uint64_t>(gen()) << 32 | gen();
-    uint32_t low = gen();
-    ulid |= (high << 16) | (low >> 16);
+    ulid |= (static_cast<uint64_t>(gen()) << 48) | (static_cast<uint64_t>(gen()) << 16) | (gen() >> 16);
 }
 
 static std::uniform_int_distribution<rand_t> Distribution_0_255(0, 255);

--- a/src/ulid_transform/ulid_wrapper.cpp
+++ b/src/ulid_transform/ulid_wrapper.cpp
@@ -9,7 +9,7 @@ void _cpp_ulid(char dst[26])
 {
     ulid::ULID ulid;
     ulid::EncodeTimeSystemClockNow(ulid);
-    ulid::EncodeEntropyRand(ulid);
+    ulid::EncodeEntropyMt19937Fast(ulid);
     ulid::MarshalTo(ulid, dst);
 }
 
@@ -20,7 +20,7 @@ void _cpp_ulid_bytes(uint8_t dst[16])
 {
     ulid::ULID ulid;
     ulid::EncodeTimeSystemClockNow(ulid);
-    ulid::EncodeEntropyRand(ulid);
+    ulid::EncodeEntropyMt19937Fast(ulid);
     ulid::MarshalBinaryTo(ulid, dst);
 }
 
@@ -32,7 +32,7 @@ void _cpp_ulid_at_time(double epoch_time, char dst[26])
 {
     ulid::ULID ulid;
     ulid::EncodeTimestamp(static_cast<int64_t>(epoch_time * 1000), ulid);
-    ulid::EncodeEntropyRand(ulid);
+    ulid::EncodeEntropyMt19937Fast(ulid);
     ulid::MarshalTo(ulid, dst);
 }
 
@@ -43,7 +43,7 @@ void _cpp_ulid_at_time_bytes(double epoch_time, uint8_t dst[16])
 {
     ulid::ULID ulid;
     ulid::EncodeTimestamp(static_cast<int64_t>(epoch_time * 1000), ulid);
-    ulid::EncodeEntropyRand(ulid);
+    ulid::EncodeEntropyMt19937Fast(ulid);
     ulid::MarshalBinaryTo(ulid, dst);
 }
 


### PR DESCRIPTION
Replace using `std::rand()` with `std::mt19937` since we didn't init `std::rand()` and it was more at risk of collisions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method for generating ULIDs using the Mersenne Twister random number generator, enhancing entropy generation.
  
- **Refactor**
  - Replaced the previous entropy generation method with a faster alternative, improving the efficiency of unique identifier creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->